### PR TITLE
Fix issue #6: HashNet does not update the beta value properly

### DIFF
--- a/configs/templates/hashnet.yaml
+++ b/configs/templates/hashnet.yaml
@@ -8,10 +8,10 @@ loss: hashnet
 arch: dpn
 backbone: alexnet
 optim: adam
-epochs: &epochs 100
+epochs: 100
 eval: 10
 # loss params
 loss_param:
   alpha: 1
   beta: 1
-  step_continuation: *epochs
+  step_continuation: 20

--- a/scripts/train_general.py
+++ b/scripts/train_general.py
@@ -118,8 +118,8 @@ def pre_epoch_operations(loss, **kwargs):
         ep = kwargs['ep']
         loss_param = kwargs['loss_param']
         step_continuation = loss_param['loss_param']['step_continuation']
-        loss_param['loss_param']['beta'] = (ep // step_continuation + 1) ** 0.5
-        logging.info(f'updated scale: {loss_param["loss_param"]["beta"]}')
+        kwargs['criterion'].beta = (ep // step_continuation + 1) ** 0.5
+        logging.info(f'updated scale: {kwargs["criterion"].beta}')
 
 
 def train_hashing(optimizer, model, train_loader, device, loss_name, loss_cfg, onehot,


### PR DESCRIPTION
I've found a bug that the `value` of beta of HashNet isn't updated, resulting in the `beta` value staying as its original (default) value for both training and testing.

https://github.com/CISiPLab/cisip-FIRe/blob/6ff37f7e98103572e4e58f5e501a55363f3508ea/scripts/train_general.py#L121

This pull request resolves issue #6 which I have opened earlier.